### PR TITLE
fix: wrapper para que no rompa el ssr del home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,8 @@
+// app/page.tsx
 import { BannerImg } from "@/components/banners/BannerImg";
 import { BannerSearch } from "@/components/banners/BannerSearch";
 import { BannerText } from "@/components/banners/BannerText";
-import { UserLocationMap } from "@/components/LocationMap/UserLocationMap";
+import ClientUserLocationMap from "@/components/LocationMap/ClientUserLocationMap";
 
 export default function Home() {
   return (
@@ -14,6 +15,7 @@ export default function Home() {
         }}
       >
         <div className="flex flex-col md:flex-row w-full max-w-6xl justify-between items-center gap-8">
+          
           {/* Texto */}
           <div className="w-full md:w-1/2 flex items-center justify-center">
             <BannerText />
@@ -26,20 +28,19 @@ export default function Home() {
         </div>
       </div>
 
-    {/* Banner de búsqueda */}
-<div className="bg-gray-100 flex flex-col items-center p-4 sm:p-6">
-  <div className="w-full max-w-6xl">
-    <BannerSearch />
-  </div>
-</div>
+      {/* Banner de búsqueda */}
+      <div className="bg-gray-100 flex flex-col items-center p-4 sm:p-6">
+        <div className="w-full max-w-6xl">
+          <BannerSearch />
+        </div>
+      </div>
 
-{/* Mapa de ubicación del usuario */}
-<div className="bg-gray-100 flex flex-col items-center p-4 sm:p-6 -mt-6">
-  <div className="w-full max-w-6xl bg-white rounded-xl shadow-lg">
-    <UserLocationMap />
-  </div>
-</div>
-      
+      {/* Mapa de ubicación del usuario */}
+      <div className="bg-gray-100 flex flex-col items-center p-4 sm:p-6 -mt-6">
+        <div className="w-full max-w-6xl bg-white rounded-xl shadow-lg">
+          <ClientUserLocationMap />
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/LocationMap/ClientUserLocationMap.tsx
+++ b/components/LocationMap/ClientUserLocationMap.tsx
@@ -1,0 +1,23 @@
+// components/LocationMap/ClientUserLocationMap.tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+// Import dinámico del mapa real
+const UserLocationMap = dynamic(
+  () => import('./UserLocationMap'),
+  { ssr: false }
+);
+
+export default function ClientUserLocationMap() {
+  return (
+    <Suspense fallback={
+      <div className="h-80 w-full bg-gray-200 rounded-xl flex items-center justify-center">
+        Cargando mapa...
+      </div>
+    }>
+      <UserLocationMap />
+    </Suspense>
+  );
+}

--- a/components/LocationMap/UserLocationMap.tsx
+++ b/components/LocationMap/UserLocationMap.tsx
@@ -1,36 +1,69 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 
+// Configuración del ícono de Leaflet
 delete (L.Icon.Default.prototype as any)._getIconUrl;
 L.Icon.Default.mergeOptions({
+  iconRetinaUrl: "/leaflet/marker-icon-2x.png", //TODO: Agregar iconos
   iconUrl: "/leaflet/marker-icon.png",
+  shadowUrl: "/leaflet/marker-shadow.png",
 });
 
-export const UserLocationMap = () => {
-  const position: [number, number] = [-34.6037, -58.3816];
-  
+const UserLocationMap = () => {
+  // Estado para la ubicación del usuario
+  const [position, setPosition] = useState<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      console.log("Geolocation no soportada por el navegador");
+      return;
+    }
+
+    // Obtenemos la ubicación inicial
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setPosition([latitude, longitude]);
+      },
+      (err) => {
+        console.error("Error obteniendo ubicación:", err);
+        // Posicion default
+        setPosition([-34.6037, -58.3816])
+      }
+    );
+  }, []);
+
+  if (!position) {
+    return (
+      <div className="h-80 w-full flex items-center justify-center bg-gray-200 rounded-xl">
+        Obteniendo ubicación...
+      </div>
+    );
+  }
 
   return (
-  <div className="text-black p-4 rounded-xl h-80 w-full">
-  <h2 className="mb-2">Mi ubicación</h2>
-  <MapContainer
-    center={position}
-    zoom={15}
-    scrollWheelZoom={false}
-    className="h-54 w-full rounded-xl"
-  >
-    <TileLayer
-      attribution='&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a>'
-      url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-    />
-    <Marker position={position}>
-      <Popup>Ubicación del usuario</Popup>
-    </Marker>
-  </MapContainer>
-</div>
-
+    <div className="text-black p-4 rounded-xl h-80 w-full">
+      <h2 className="mb-2">Mi ubicación</h2>
+      <MapContainer
+        center={position}
+        zoom={15}
+        scrollWheelZoom={false}
+        className="h-54 w-full rounded-xl"
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        <Marker position={position}>
+          <Popup>Ubicación del usuario</Popup>
+        </Marker>
+      </MapContainer>
+    </div>
   );
 };
+
+export default UserLocationMap;


### PR DESCRIPTION
Se creo un wrapper que envuelve la funcionalidad del mapa. Esto permite que el home tenga SSR y que el mapa se cargue del lado del cliente. También se agrego la funcionalidad de geolocalización y se coloco las coordenadas existentes como default en caso que el usuario no permita el uso de dicha herramienta.

Bug:
<img width="1218" height="297" alt="image" src="https://github.com/user-attachments/assets/9460b3c2-36fa-4b18-8c4b-ab591627cd92" />
