### PR TITLE
eliminado StudioType/Payload c\whitelist en registerstudioowner/ registro dueño hecho

### DIFF
--- a/components/forms/StudioForm.tsx
+++ b/components/forms/StudioForm.tsx
@@ -4,6 +4,7 @@ import { Formik, Form, Field, ErrorMessage } from "formik";
 import * as Yup from "yup";
 import { ReactNode, useState } from "react";
 import { FaBuilding } from "react-icons/fa";
+import { registerStudioOwner } from "@/services/register.services";
 
 const brand = {
     primary: "#015E88",
@@ -40,11 +41,7 @@ function Label({
 
 function HelpError({ name }: { name: string }) {
     return (
-        <ErrorMessage
-            name={name}
-            component="div"
-            className="text-xs text-red-600 mt-1"
-        />
+        <ErrorMessage name={name} component="div" className="text-xs text-red-600 mt-1" />
     );
 }
 
@@ -67,7 +64,7 @@ const Input = ({
             <Field
                 id={name}
                 name={name}
-                type={type}
+                type={inputType}
                 placeholder={placeholder}
                 className="w-full border border-gray-300 rounded-lg bg-white px-3 py-2 text-sm text-gray-800 shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
@@ -75,9 +72,7 @@ const Input = ({
             {togglePassword && (
                 <button
                     type="button"
-                    aria-label={
-                        show ? "Ocultar contraseña" : "Mostrar contraseña"
-                    }
+                    aria-label={show ? "Ocultar contraseña" : "Mostrar contraseña"}
                     onClick={() => setShow((s) => !s)}
                     className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
@@ -89,11 +84,7 @@ const Input = ({
                             stroke="currentColor"
                             strokeWidth="1.6"
                         >
-                            <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M3 3l18 18"
-                            />
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18" />
                             <path
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
@@ -131,14 +122,10 @@ const StudioSchema = Yup.object().shape({
         .required("Requerido")
         .min(8, "Debe tener al menos 8 caracteres")
         .matches(/[A-Z]/, "Debe contener al menos una mayúscula")
-        .matches(
-            /[!@#$%^&*(),.?":{}|<>]/,
-            "Debe contener un caracter especial"
-        ),
+        .matches(/[!@#$%^&*(),.?":{}|<>]/, "Debe contener un caracter especial"),
     confirmPassword: Yup.string()
         .oneOf([Yup.ref("password")], "Las contraseñas deben coincidir")
         .required("Requerido"),
-
     phoneNumber: Yup.string().required("Requerido"),
     studioName: Yup.string().required("Requerido"),
     address: Yup.string().required("Requerido"),
@@ -161,8 +148,8 @@ export default function StudioConnectStudioForm() {
                         Registrate como Owner de estudio
                     </h1>
                     <p className="mt-2 text-sm md:text-base text-gray-200">
-                        Únete a nuestra red de estudios de grabación
-                        profesionales y conéctate con músicos de todo el mundo.
+                        Únete a nuestra red de estudios de grabación profesionales y
+                        conéctate con músicos de todo el mundo.
                     </p>
                 </div>
             </div>
@@ -184,37 +171,49 @@ export default function StudioConnectStudioForm() {
                             description: "",
                         }}
                         validationSchema={StudioSchema}
-                        onSubmit={(values) => {
-                            console.log(
-                                "StudioConnect – form payload:",
-                                values
-                            );
-                            alert("Formulario enviado! Revisa la consola.");
+                        onSubmit={async (values, { setSubmitting, resetForm }) => {
+                            try {
+                                const payload = {
+                                    ownerInfo: {
+                                        firstName: values.firstName,
+                                        lastName: values.lastName,
+                                        email: values.email,
+                                        phoneNumber: values.phoneNumber,
+                                        password: values.password,
+                                    },
+                                    studioInfo: {
+                                        name: values.studioName,
+                                        city: values.city,
+                                        province: values.province,
+                                        address: values.address,
+                                        description: values.description,
+                                    },
+                                };
+                                const res = await registerStudioOwner(payload);
+                                alert(res.message || "Registro completado");
+                                resetForm();
+                            } catch (err: any) {
+                                alert(err?.response?.data?.message ?? "Error al registrar");
+                            } finally {
+                                setSubmitting(false);
+                            }
                         }}
                     >
                         {() => (
                             <Form className="space-y-6">
-                                <SectionTitle>
-                                    Información del Propietario
-                                </SectionTitle>
+                                <SectionTitle>Información del Propietario</SectionTitle>
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <div>
                                         <Label htmlFor="firstName" required>
                                             Nombre
                                         </Label>
-                                        <Input
-                                            name="firstName"
-                                            placeholder="Juan"
-                                        />
+                                        <Input name="firstName" placeholder="Juan" />
                                     </div>
                                     <div>
                                         <Label htmlFor="lastName" required>
                                             Apellido
                                         </Label>
-                                        <Input
-                                            name="lastName"
-                                            placeholder="Pérez"
-                                        />
+                                        <Input name="lastName" placeholder="Pérez" />
                                     </div>
                                 </div>
 
@@ -222,11 +221,7 @@ export default function StudioConnectStudioForm() {
                                     <Label htmlFor="email" required>
                                         Email
                                     </Label>
-                                    <Input
-                                        name="email"
-                                        type="email"
-                                        placeholder="correo@ejemplo.com"
-                                    />
+                                    <Input name="email" type="email" placeholder="correo@ejemplo.com" />
                                 </div>
 
                                 <div>
@@ -257,54 +252,37 @@ export default function StudioConnectStudioForm() {
                                     <Label htmlFor="phoneNumber" required>
                                         Teléfono
                                     </Label>
-                                    <Input
-                                        name="phoneNumber"
-                                        placeholder="+54 11 1234 5678"
-                                    />
+                                    <Input name="phoneNumber" placeholder="+54 11 1234 5678" />
                                 </div>
 
-                                <SectionTitle>
-                                    Información del Estudio
-                                </SectionTitle>
+                                <SectionTitle>Información del Estudio</SectionTitle>
 
                                 <div>
                                     <Label htmlFor="studioName" required>
                                         Nombre del estudio
                                     </Label>
-                                    <Input
-                                        name="studioName"
-                                        placeholder="Studio Connect"
-                                    />
+                                    <Input name="studioName" placeholder="Studio Connect" />
                                 </div>
 
                                 <div>
                                     <Label htmlFor="address" required>
                                         Dirección
                                     </Label>
-                                    <Input
-                                        name="address"
-                                        placeholder="Av. Siempre Viva 123"
-                                    />
+                                    <Input name="address" placeholder="Av. Siempre Viva 123" />
                                 </div>
 
                                 <div>
                                     <Label htmlFor="province" required>
                                         Provincia
                                     </Label>
-                                    <Input
-                                        name="province"
-                                        placeholder="Buenos Aires"
-                                    />
+                                    <Input name="province" placeholder="Buenos Aires" />
                                 </div>
 
                                 <div>
                                     <Label htmlFor="city" required>
                                         Ciudad
                                     </Label>
-                                    <Input
-                                        name="city"
-                                        placeholder="Capital Federal"
-                                    />
+                                    <Input name="city" placeholder="Capital Federal" />
                                 </div>
 
                                 <div>
@@ -326,9 +304,7 @@ export default function StudioConnectStudioForm() {
                                     <button
                                         type="submit"
                                         className="w-full py-2 px-4 rounded-lg text-white font-medium shadow-md hover:opacity-90"
-                                        style={{
-                                            backgroundColor: brand.primary,
-                                        }}
+                                        style={{ backgroundColor: brand.primary }}
                                     >
                                         Registrarme
                                     </button>

--- a/services/register.services.ts
+++ b/services/register.services.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/";
+
+export interface OwnerInfo {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phoneNumber: string;
+  password: string;
+}
+
+export interface StudioInfo {
+  name: string;
+  city: string;
+  province: string;
+  address: string;
+  description: string;
+}
+
+export interface StudioOwnerRegisterPayload {
+  ownerInfo: OwnerInfo;
+  studioInfo: StudioInfo;
+}
+
+export interface StudioOwnerRegisterResponse {
+  message: string;
+}
+
+export async function registerStudioOwner(
+  data: StudioOwnerRegisterPayload
+): Promise<StudioOwnerRegisterResponse> {
+  const url = new URL("auth/register/studio-owner", API).toString();
+  const payload: StudioOwnerRegisterPayload = {
+    ownerInfo: {
+      firstName: data.ownerInfo.firstName,
+      lastName: data.ownerInfo.lastName,
+      email: data.ownerInfo.email,
+      phoneNumber: data.ownerInfo.phoneNumber,
+      password: data.ownerInfo.password,
+    },
+    studioInfo: {
+      name: data.studioInfo.name,
+      city: data.studioInfo.city,
+      province: data.studioInfo.province,
+      address: data.studioInfo.address,
+      description: data.studioInfo.description,
+    },
+  };
+  const res = await axios.post(url, payload, { withCredentials: true });
+  return res.data as StudioOwnerRegisterResponse;
+}


### PR DESCRIPTION
Qué cambie:
- Elimino `studioType` del formulario de registro de Owner (UI + Yup).
- Actualizo `onSubmit` para mapear solo campos permitidos.
- Servicio `registerStudioOwner`: payload con whitelist (no viaja `studioType` aunque quede en values).

Motivo:
El tipo de estudio pasa a definirse por **salas** (roomType). El endpoint de registro no debe recibir `studioInfo.studioType`.

Alcance:
Frontend:
- `StudioForm.tsx`: sin `<select name="studioType">`, sin validación de ese campo.
- `register.services.ts`: sanitize/whitelist del payload.

Backend (dependencia):
- El endpoint `POST /auth/register/studio-owner` debe aceptar `studioInfo` sin `studioType`.
- Ideal: ignorar claves extra para compatibilidad.

## Pruebas (QA)
1. Completar el formulario y enviar.
2. Network → Request Payload no muestra `studioType`.
3. Respuesta 200/201 con mensaje de éxito.