### PR TITLE
✨ Registro Owner: formulario solo propietario, payload compatible con con backend y redirect a login

### DIFF
--- a/components/forms/StudioForm.tsx
+++ b/components/forms/StudioForm.tsx
@@ -127,11 +127,6 @@ const StudioSchema = Yup.object().shape({
         .oneOf([Yup.ref("password")], "Las contraseñas deben coincidir")
         .required("Requerido"),
     phoneNumber: Yup.string().required("Requerido"),
-    studioName: Yup.string().required("Requerido"),
-    address: Yup.string().required("Requerido"),
-    city: Yup.string().required("Requerido"),
-    province: Yup.string().required("Requerido"),
-    description: Yup.string().required("Requerido"),
 });
 
 export default function StudioConnectStudioForm() {
@@ -164,11 +159,6 @@ export default function StudioConnectStudioForm() {
                             password: "",
                             confirmPassword: "",
                             phoneNumber: "",
-                            studioName: "",
-                            address: "",
-                            city: "",
-                            province: "",
-                            description: "",
                         }}
                         validationSchema={StudioSchema}
                         onSubmit={async (values, { setSubmitting, resetForm }) => {
@@ -182,16 +172,18 @@ export default function StudioConnectStudioForm() {
                                         password: values.password,
                                     },
                                     studioInfo: {
-                                        name: values.studioName,
-                                        city: values.city,
-                                        province: values.province,
-                                        address: values.address,
-                                        description: values.description,
+                                        name: "Pendiente",
+                                        city: "Pendiente",
+                                        province: "Pendiente",
+                                        address: "Pendiente 123",
+                                        description: "Registro de owner sin datos de estudio por ahora.",
                                     },
                                 };
                                 const res = await registerStudioOwner(payload);
                                 alert(res.message || "Registro completado");
                                 resetForm();
+                                window.location.href = "/login";
+
                             } catch (err: any) {
                                 alert(err?.response?.data?.message ?? "Error al registrar");
                             } finally {
@@ -253,51 +245,6 @@ export default function StudioConnectStudioForm() {
                                         Teléfono
                                     </Label>
                                     <Input name="phoneNumber" placeholder="+54 11 1234 5678" />
-                                </div>
-
-                                <SectionTitle>Información del Estudio</SectionTitle>
-
-                                <div>
-                                    <Label htmlFor="studioName" required>
-                                        Nombre del estudio
-                                    </Label>
-                                    <Input name="studioName" placeholder="Studio Connect" />
-                                </div>
-
-                                <div>
-                                    <Label htmlFor="address" required>
-                                        Dirección
-                                    </Label>
-                                    <Input name="address" placeholder="Av. Siempre Viva 123" />
-                                </div>
-
-                                <div>
-                                    <Label htmlFor="province" required>
-                                        Provincia
-                                    </Label>
-                                    <Input name="province" placeholder="Buenos Aires" />
-                                </div>
-
-                                <div>
-                                    <Label htmlFor="city" required>
-                                        Ciudad
-                                    </Label>
-                                    <Input name="city" placeholder="Capital Federal" />
-                                </div>
-
-                                <div>
-                                    <Label htmlFor="description" required>
-                                        Descripción del estudio
-                                    </Label>
-                                    <Field
-                                        as="textarea"
-                                        id="description"
-                                        name="description"
-                                        placeholder="Contanos sobre tu sala o estudio..."
-                                        rows={4}
-                                        className="w-full border border-gray-300 rounded-lg bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                                    />
-                                    <HelpError name="description" />
                                 </div>
 
                                 <div className="pt-4">

--- a/services/register.services.ts
+++ b/services/register.services.ts
@@ -1,52 +1,10 @@
+// src/services/register.services.ts
 import axios from "axios";
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/";
 
-export interface OwnerInfo {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phoneNumber: string;
-  password: string;
-}
-
-export interface StudioInfo {
-  name: string;
-  city: string;
-  province: string;
-  address: string;
-  description: string;
-}
-
-export interface StudioOwnerRegisterPayload {
-  ownerInfo: OwnerInfo;
-  studioInfo: StudioInfo;
-}
-
-export interface StudioOwnerRegisterResponse {
-  message: string;
-}
-
-export async function registerStudioOwner(
-  data: StudioOwnerRegisterPayload
-): Promise<StudioOwnerRegisterResponse> {
+export async function registerStudioOwner(data: any) {
   const url = new URL("auth/register/studio-owner", API).toString();
-  const payload: StudioOwnerRegisterPayload = {
-    ownerInfo: {
-      firstName: data.ownerInfo.firstName,
-      lastName: data.ownerInfo.lastName,
-      email: data.ownerInfo.email,
-      phoneNumber: data.ownerInfo.phoneNumber,
-      password: data.ownerInfo.password,
-    },
-    studioInfo: {
-      name: data.studioInfo.name,
-      city: data.studioInfo.city,
-      province: data.studioInfo.province,
-      address: data.studioInfo.address,
-      description: data.studioInfo.description,
-    },
-  };
-  const res = await axios.post(url, payload, { withCredentials: true });
-  return res.data as StudioOwnerRegisterResponse;
+  const res = await axios.post(url, data, { withCredentials: true });
+  return res.data;
 }


### PR DESCRIPTION
Se simplifica el formulario de registro de Owner:
- Se eliminó la sección de Información del Estudio en el front.
- Se validan únicamente los campos del propietario (nombre, apellido, email, contraseña, confirmación, teléfono).
- El payload enviado al backend incluye `ownerInfo` real y `studioInfo` placeholder para mantener compatibilidad.
- Se agregó redirect automático al login después del registro exitoso.

Pendiente para backend:
- Ajustar DTO de registro para que `studioInfo` sea opcional, evitando necesidad de enviar placeholders.
