### PR TITLE
feat(myStudio): modales de edición de estudio y salas + unificación de estilos

### DIFF
--- a/components/myStudio/ChipsInput.tsx
+++ b/components/myStudio/ChipsInput.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useState, KeyboardEvent } from "react";
+
+type ChipsInputProps = {
+  id?: string;
+  label?: string;
+  placeholder?: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  variant?: "light" | "dark";
+};
+
+export default function ChipsInput({
+  id,
+  label,
+  placeholder = "Escribí y presioná Enter…",
+  value,
+  onChange,
+  disabled,
+  variant = "light",
+}: ChipsInputProps) {
+  const [draft, setDraft] = useState("");
+
+  const addChip = (chip: string) => {
+    const clean = chip.trim();
+    if (!clean) return;
+    if (value.includes(clean)) return;
+    onChange([...value, clean]);
+    setDraft("");
+  };
+
+  const removeChip = (chip: string) => {
+    onChange(value.filter((c) => c !== chip));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addChip(draft);
+    }
+  };
+
+  const isDark = variant === "dark";
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label
+          htmlFor={id}
+          className={`mb-1 block text-sm ${isDark ? "text-white/80" : "text-gray-700"}`}
+        >
+          {label}
+        </label>
+      )}
+
+      <div
+        className={[
+          "flex flex-wrap items-center gap-2 rounded-lg p-2",
+          isDark
+            ? "border border-white/15 bg-white/5"
+            : "border border-gray-300 bg-white",
+        ].join(" ")}
+      >
+        {value.map((chip) => (
+          <span
+            key={chip}
+            className={[
+              "inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm",
+              isDark
+                ? "border border-white/15 bg-white/10 text-white"
+                : "border border-gray-300 bg-gray-50 text-gray-800",
+            ].join(" ")}
+          >
+            {chip}
+            <button
+              type="button"
+              onClick={() => removeChip(chip)}
+              className={[
+                "rounded-full px-1",
+                isDark
+                  ? "text-white/70 hover:bg-white/15"
+                  : "text-gray-500 hover:bg-gray-200",
+              ].join(" ")}
+              aria-label={`Quitar ${chip}`}
+              disabled={disabled}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          id={id}
+          className={[
+            "min-w-[180px] flex-1 border-0 bg-transparent text-sm outline-none",
+            isDark ? "text-white placeholder-white/40" : "text-gray-900",
+          ].join(" ")}
+          placeholder={placeholder}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/myStudio/EditStudioModal.tsx
+++ b/components/myStudio/EditStudioModal.tsx
@@ -1,0 +1,270 @@
+"use client";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom"; // ← agregado
+import { FiSettings } from "react-icons/fi";
+import ChipsInput from "./ChipsInput";
+import { updateMyStudio, type UpdateStudioPayload } from "@/services/myStudio.services";
+
+type EditStudioModalProps = {
+  open: boolean;
+  onClose: () => void;
+  initial?: (Partial<UpdateStudioPayload> & Record<string, any> & { name?: string });
+  onSaved?: (updated: any) => void;
+};
+
+export default function EditStudioModal({
+  open,
+  onClose,
+  initial,
+  onSaved,
+}: EditStudioModalProps) {
+  const [loading, setLoading] = useState(false);
+  const [mounted, setMounted] = useState(false); // ← para evitar mismatch SSR
+  const [form, setForm] = useState<UpdateStudioPayload>({
+    name: "",
+    city: "",
+    province: "",
+    address: "",
+    phoneNumber: "",
+    email: "",
+    description: "",
+    services: [],
+    photos: [],
+  });
+
+  useEffect(() => setMounted(true), []); // ← portal listo en cliente
+
+  useEffect(() => {
+    if (initial) {
+      setForm({
+        name: initial.name ?? "",
+        city: initial.city ?? "",
+        province: initial.province ?? "",
+        address: initial.address ?? "",
+        phoneNumber: initial.phoneNumber ?? "",
+        email: initial.email ?? "",
+        description: initial.description ?? "",
+        services: initial.services ?? [],
+        photos: initial.photos ?? [],
+      });
+    }
+  }, [initial]);
+
+  const handleChange = (key: keyof UpdateStudioPayload, val: any) => {
+    setForm((prev) => ({ ...prev, [key]: val }));
+  };
+
+  const toHHMM = (val: any, fallback: string) => {
+    const s = String(val ?? "").trim();
+    const m = s.match(/^(\d{1,2}):(\d{2})$/);
+    if (m) {
+      const hh = String(Math.min(23, parseInt(m[1], 10))).padStart(2, "0");
+      const mm = String(Math.min(59, parseInt(m[2], 10))).padStart(2, "0");
+      return `${hh}:${mm}`;
+    }
+    return fallback;
+  };
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+
+      const allowed: (keyof UpdateStudioPayload)[] = [
+        "name",
+        "city",
+        "province",
+        "address",
+        "description",
+        "services",
+        "photos",
+        "phoneNumber",
+        "email",
+      ];
+
+      const base = Object.fromEntries(
+        Object.entries(form).filter(([k, v]) => {
+          if (!allowed.includes(k as keyof UpdateStudioPayload)) return false;
+          if (Array.isArray(v)) return v.length > 0;
+          return v !== "" && v !== undefined && v !== null;
+        })
+      ) as UpdateStudioPayload;
+
+      const openingTime = toHHMM((initial as any)?.openingTime, "09:00");
+      const closingTime = toHHMM((initial as any)?.closingTime, "18:00");
+
+      const payload: UpdateStudioPayload & { openingTime: string; closingTime: string } = {
+        ...base,
+        openingTime,
+        closingTime,
+      };
+
+      const updated = await updateMyStudio(payload);
+      onSaved?.(updated);
+      onClose();
+    } catch (e: any) {
+      console.error(e?.response?.data ?? e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!open || !mounted) return null;
+
+  const modal = (
+    // Overlay sin blur para no desenfocar el fondo
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/45 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      {/* Panel azul translúcido, más ALTO, con scroll interno; evita cerrar al click interno */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-3xl min-h-[80vh] md:min-h-[80vh]
+                   overflow-hidden rounded-2xl ring-1 ring-white/10 shadow-2xl
+                   bg-gradient-to-b from-[#0F3B57]/90 via-[#0B2746]/90 to-[#071E32]/90
+                   backdrop-blur-xl text-white flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <span className="rounded-xl bg-[#03597E]/25 p-2 ring-1 ring-[#03597E]/30">
+              <FiSettings className="h-5 w-5 text-[#7fd1ff]" />
+            </span>
+            <h2 className="text-base font-semibold tracking-tight">Editar datos del estudio</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-md px-2 text-white/70 hover:bg-white/10"
+            aria-label="Cerrar"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body (crece y scrollea) */}
+        <div className="grid grid-cols-1 gap-4 px-6 py-6 md:grid-cols-2 flex-1 overflow-y-auto">
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Nombre</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.name ?? ""}
+              onChange={(e) => handleChange("name", e.target.value)}
+              placeholder="Mi Estudio"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Ciudad</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.city ?? ""}
+              onChange={(e) => handleChange("city", e.target.value)}
+              placeholder="Bogotá"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Provincia</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.province ?? ""}
+              onChange={(e) => handleChange("province", e.target.value)}
+              placeholder="Cundinamarca"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Dirección</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.address ?? ""}
+              onChange={(e) => handleChange("address", e.target.value)}
+              placeholder="Calle Falsa 123"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Teléfono</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.phoneNumber ?? ""}
+              onChange={(e) => handleChange("phoneNumber", e.target.value)}
+              placeholder="+54 9..."
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-white/80">Email</label>
+            <input
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.email ?? ""}
+              onChange={(e) => handleChange("email", e.target.value)}
+              placeholder="info@studio.com"
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <label className="mb-1 block text-sm text-white/80">Descripción</label>
+            <textarea
+              rows={3}
+              className="w-full rounded-lg border border-white/15 bg-white/5 p-2 text-white placeholder-white/40 outline-none
+                         focus:ring-2 focus:ring-[#03597E]/50 focus:border-[#03597E]/40"
+              value={form.description ?? ""}
+              onChange={(e) => handleChange("description", e.target.value)}
+              placeholder="Breve descripción del estudio…"
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <ChipsInput
+              label="Servicios (chips)"
+              value={form.services ?? []}
+              onChange={(arr) => handleChange("services", arr)}
+              placeholder="Ej.: Grabación, Mezcla, Ensayo…"
+              variant="dark"
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <ChipsInput
+              label="Fotos (URLs)"
+              value={form.photos ?? []}
+              onChange={(arr) => handleChange("photos", arr)}
+              placeholder="Pegá URL y Enter…"
+              variant="dark"
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 border-t border-white/10 bg-[#0B2746]/60 px-6 py-4">
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-sm text-white hover:bg-white/15"
+            disabled={loading}
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="rounded-lg bg-[#03597E] px-4 py-2 text-sm text-white hover:bg-[#024d6f]"
+            disabled={loading}
+          >
+            {loading ? "Guardando…" : "Guardar cambios"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ← Render fuera del contenedor que recorta (evita el “corte”)
+  return createPortal(modal, document.body);
+}

--- a/components/myStudio/MyStudioClient.tsx
+++ b/components/myStudio/MyStudioClient.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import { getMyStudio, type Studio } from "@/services/myStudio.services";
 import MyStudioHeader from "./MyStudioHeader";
 import RoomsSection from "./RoomsSection";
+import EditStudioModal from "@/components/myStudio/EditStudioModal";
 
-// Íconos
 import { LuLayoutDashboard } from "react-icons/lu";
 import { FaMapMarkerAlt, FaInfoCircle } from "react-icons/fa";
 
@@ -13,6 +13,7 @@ export default function MyStudioClient() {
   const [studio, setStudio] = useState<Studio | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const [openEdit, setOpenEdit] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -28,21 +29,23 @@ export default function MyStudioClient() {
   }, []);
 
   if (loading) return <div className="bg-white rounded-xl shadow p-6">Cargando…</div>;
-  if (err)      return <div className="bg-red-50 text-red-700 rounded-xl shadow p-6">{err}</div>;
-  if (!studio)  return <div className="bg-white rounded-xl shadow p-6">No se encontró tu estudio.</div>;
+  if (err) return <div className="bg-red-50 text-red-700 rounded-xl shadow p-6">{err}</div>;
+  if (!studio) return <div className="bg-white rounded-xl shadow p-6">No se encontró tu estudio.</div>;
 
   const card =
     "rounded-2xl overflow-hidden shadow-[0_12px_24px_-12px_rgba(0,0,0,0.5)] ring-1 ring-white/10 " +
     "bg-gradient-to-b from-[#0F3B57] via-[#0B2746] to-[#071E32] text-white backdrop-blur-md p-4 md:p-6";
 
   const location = [studio.city, studio.province].filter(Boolean).join(", ");
+  const headerLocation = [studio.address, location].filter(Boolean).join(" • ");
 
   return (
     <section className={card}>
-      {/* Header */}
-      <MyStudioHeader />
+      <MyStudioHeader
+        onEditStudio={() => setOpenEdit(true)}
+        locationText={headerLocation}
+      />
 
-      {/* Bloques de info con íconos */}
       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
         <div className="rounded-xl border border-white/12 bg-white/10 p-4">
           <div className="flex items-center gap-2 text-sm text-white/70">
@@ -50,9 +53,7 @@ export default function MyStudioClient() {
             <span>Resumen</span>
           </div>
           <p className="mt-1 text-base font-semibold">{studio.name ?? "—"}</p>
-          <p className="text-sm text-white/80">
-            Salas activas: <b></b>
-          </p>
+          <p className="text-sm text-white/80">Salas activas: <b>0</b></p>
         </div>
 
         <div className="rounded-xl border border-white/12 bg-white/10 p-4">
@@ -72,17 +73,31 @@ export default function MyStudioClient() {
             <span>Info</span>
           </div>
           <p className="mt-1 text-sm text-white/80">
-            Editá portada, descripción y contacto desde{" "}
-            <span className="font-semibold">“Editar datos del estudio”.</span>
+            Editá portada, descripción y contacto desde <span className="font-semibold">“Editar datos del estudio”.</span>
           </p>
         </div>
       </div>
 
-      {/* Salas */}
       <div className="mt-6">
         <h3 className="mb-3 text-xl font-semibold text-white/95">Mis salas</h3>
         <RoomsSection />
       </div>
+
+      <EditStudioModal
+        open={openEdit}
+        onClose={() => setOpenEdit(false)}
+        initial={{
+          name: studio.name,
+          city: studio.city,
+          province: studio.province,
+          address: studio.address,
+          description: studio.description,
+          services: studio.services ?? [],
+          openingTime: (studio as any).openingTime, 
+          closingTime: (studio as any).closingTime, 
+        }}
+        onSaved={(updated) => setStudio(updated)}
+      />
     </section>
   );
 }

--- a/components/myStudio/MyStudioHeader.tsx
+++ b/components/myStudio/MyStudioHeader.tsx
@@ -2,31 +2,40 @@
 
 import Link from "next/link";
 
-export default function MyStudioHeader() {
-  return (
-    <section className="bg-white rounded-xl shadow-lg p-6 mb-6">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <div>
-          <h2 className="text-xl md:text-2xl font-semibold">Nombre de mi estudio</h2>
-          <p className="text-sm text-gray-500">Ubicación • Ciudad, Provincia</p>
-        </div>
+type Props = {
+  onEditStudio?: () => void;
+  locationText?: string;
+};
 
-        <div className="flex flex-wrap gap-2">
-          <Link
-            href="#"
-            className="px-4 py-2 rounded-lg text-white shadow bg-[#015E88] hover:opacity-90"
-          >
+export default function MyStudioHeader({ onEditStudio, locationText }: Props) {
+  // Estilo unificado: igual a los otros botones azules (bajos, elegantes)
+  const btnBlue =
+    "inline-flex items-center justify-center py-1.5 rounded-md px-4 text-sm font-medium " +
+    "text-white bg-[#03597E] hover:bg-[#024d6f] " + // azul de la app + hover
+    "shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40";
+
+  return (
+    <div className="flex items-center justify-between rounded-xl bg-white p-4 text-gray-800">
+      <div className="h-15 w-full rounded-lg bg-gray-100/80 px-3 py-2 text-sm text-gray-600 flex items-center">
+        {locationText || "Ubicación • Ciudad, Provincia"}
+      </div>
+
+      <div className="ml-4 flex gap-4">
+        {/* Ambos con el MISMO estilo azul y la misma altura */}
+        {onEditStudio ? (
+          <button onClick={onEditStudio} className={btnBlue}>
+            Editar datos del estudio
+          </button>
+        ) : (
+          <Link href="/studioForm" className={btnBlue}>
             Editar datos del estudio
           </Link>
+        )}
 
-          <Link
-            href="/studioRooms"
-            className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-100"
-          >
-            Editar salas
-          </Link>
-        </div>
+        <Link href="/studioRooms" className={btnBlue}>
+          Editar salas
+        </Link>
       </div>
-    </section>
+    </div>
   );
 }

--- a/components/myStudio/RoomsManagerModal.tsx
+++ b/components/myStudio/RoomsManagerModal.tsx
@@ -1,0 +1,176 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+
+export type RoomDraft = {
+  id: string;
+  name: string;
+  capacity?: number;
+  price?: number;
+  photo?: string; // URL opcional
+};
+
+type RoomsManagerModalProps = {
+  open: boolean;
+  onClose: () => void;
+  initial?: RoomDraft[];         // estado inicial desde el padre
+  onChange?: (rooms: RoomDraft[]) => void; // devuelve el array final
+};
+
+function uid() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export default function RoomsManagerModal({
+  open,
+  onClose,
+  initial = [],
+  onChange,
+}: RoomsManagerModalProps) {
+  const [rooms, setRooms] = useState<RoomDraft[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = useMemo(() => rooms.find(r => r.id === selectedId) ?? null, [rooms, selectedId]);
+
+  useEffect(() => {
+    setRooms(initial);
+  }, [initial]);
+
+  const addRoom = () => {
+    const r: RoomDraft = { id: uid(), name: "Nueva sala" };
+    setRooms((prev) => [r, ...prev]);
+    setSelectedId(r.id);
+  };
+
+  const updateSelected = (patch: Partial<RoomDraft>) => {
+    if (!selected) return;
+    setRooms((prev) => prev.map(r => r.id === selected.id ? { ...r, ...patch } : r));
+  };
+
+  const removeSelected = () => {
+    if (!selected) return;
+    const next = rooms.filter(r => r.id !== selected.id);
+    setRooms(next);
+    setSelectedId(null);
+  };
+
+  const handleSave = () => {
+    onChange?.(rooms);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-4xl rounded-2xl border border-white/10 bg-gradient-to-b from-[#0A2233] to-[#061521] p-5 text-white shadow-xl backdrop-blur">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Administrar salas</h2>
+          <button onClick={onClose} className="rounded px-2 text-white/80 hover:bg-white/10" aria-label="Cerrar">✕</button>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {/* Listado */}
+          <div className="md:col-span-1">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm text-white/80">Salas ({rooms.length})</span>
+              <button onClick={addRoom} className="rounded-lg bg-white/10 px-3 py-1 text-sm hover:bg-white/20">
+                + Agregar
+              </button>
+            </div>
+
+            <ul className="space-y-2">
+              {rooms.map((r) => (
+                <li key={r.id}>
+                  <button
+                    className={`w-full rounded-lg border border-white/10 px-3 py-2 text-left hover:bg-white/10 ${selectedId === r.id ? "bg-white/10" : ""}`}
+                    onClick={() => setSelectedId(r.id)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{r.name || "Sin nombre"}</span>
+                      {(r.capacity || r.price) && (
+                        <span className="text-xs text-white/70">
+                          {r.capacity ? `${r.capacity} pax` : ""} {r.price ? `• $${r.price}` : ""}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Editor */}
+          <div className="md:col-span-2">
+            {!selected ? (
+              <div className="flex h-full items-center justify-center rounded-xl border border-white/10 bg-white/5 p-6 text-white/70">
+                Seleccioná una sala para editar.
+              </div>
+            ) : (
+              <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-4">
+                <div>
+                  <label className="mb-1 block text-sm text-white/80">Nombre</label>
+                  <input
+                    className="w-full rounded-lg border border-white/10 bg-white/0 p-2 outline-none"
+                    value={selected.name}
+                    onChange={(e) => updateSelected({ name: e.target.value })}
+                    placeholder="Sala Principal"
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="mb-1 block text-sm text-white/80">Capacidad (personas)</label>
+                    <input
+                      type="number"
+                      className="w-full rounded-lg border border-white/10 bg-white/0 p-2 outline-none"
+                      value={selected.capacity ?? ""}
+                      onChange={(e) => updateSelected({ capacity: e.target.value ? Number(e.target.value) : undefined })}
+                      placeholder="10"
+                      min={0}
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-sm text-white/80">Precio (por hora)</label>
+                    <input
+                      type="number"
+                      className="w-full rounded-lg border border-white/10 bg-white/0 p-2 outline-none"
+                      value={selected.price ?? ""}
+                      onChange={(e) => updateSelected({ price: e.target.value ? Number(e.target.value) : undefined })}
+                      placeholder="15000"
+                      min={0}
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm text-white/80">Foto (URL)</label>
+                  <input
+                    className="w-full rounded-lg border border-white/10 bg-white/0 p-2 outline-none"
+                    value={selected.photo ?? ""}
+                    onChange={(e) => updateSelected({ photo: e.target.value || undefined })}
+                    placeholder="https://…"
+                  />
+                </div>
+
+                <div className="flex justify-between pt-2">
+                  <button
+                    onClick={removeSelected}
+                    className="rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm hover:bg-white/20"
+                  >
+                    Eliminar sala
+                  </button>
+                  <button
+                    onClick={handleSave}
+                    className="rounded-lg bg-[#C93C3C]/90 px-4 py-2 text-sm hover:bg-[#C93C3C]"
+                  >
+                    Guardar cambios
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/services/myStudio.services.ts
+++ b/services/myStudio.services.ts
@@ -10,6 +10,7 @@ export type Studio = {
   country?: string;
   rating?: number;
   reviewsCount?: number;
+  services?: string[]; // ← agregado: habilita services en el Studio
 };
 
 export type Room = {
@@ -26,17 +27,40 @@ export type Room = {
 
 type MyStudioRaw =
   | { studio: Studio }
-  | Studio; 
+  | Studio;
+
+export type UpdateStudioPayload = {
+  name?: string;
+  city?: string;
+  province?: string;
+  address?: string;
+  phoneNumber?: string;
+  email?: string;
+  description?: string;
+  services?: string[];
+  photos?: string[];
+  openingTime?: string; 
+  closingTime?: string;
+};
 
 export async function getMyStudio(): Promise<{ studio: Studio }> {
-  // 1) Traigo el estudio del owner (sin /api)
   const { data } = await http.get<MyStudioRaw>("/owners/me/studio");
-
-  // Soporto ambas formas de respuesta: { studio, rooms } o solo Studio
   const studio: Studio = (data as any)?.studio ?? (data as Studio);
 
   if (!studio?.id) {
     throw new Error("Respuesta inesperada: no llegó el studio con id");
   }
-  return { studio};
+  return { studio };
+}
+
+export async function updateMyStudio(payload: UpdateStudioPayload) {
+  const { data } = await http.put("/owners/me/studio", payload);
+  return data;
+}
+
+export async function getMyRooms(): Promise<Room[]> {
+  const { data } = await http.get("/owners/me/studio/rooms");
+  if (Array.isArray(data)) return data as Room[];
+  if (Array.isArray((data as any)?.rooms)) return (data as any).rooms as Room[];
+  return [];
 }


### PR DESCRIPTION
Este PR agrega los modales de edición e integra mejoras visuales en “Mi Estudio”.

- EditStudioModal.tsx: modal vítreo (degradé azul), más alto (min-h 75–80vh), overlay sin blur, scroll interno y footer fijo. Render con portal para evitar recortes.
- MyStudioHeader.tsx: botones unificados (pill azules), menor altura, hover acorde a la paleta.
- MyStudioClient.tsx: pasa `locationText` al header y muestra preview informativo de salas (nombre, meta y estado).
- services/myStudio.services.ts: `updateMyStudio(payload)` y `getMyRooms()` tolerante a `{ rooms: [] }` o `[]`.

✔ Modales funcionales  
✔ Estilo consistente con la app  
✔ Bloque “Mis salas” con info útil
